### PR TITLE
Add api.newrelic.com as default API hostname

### DIFF
--- a/src/newrelic.coffee
+++ b/src/newrelic.coffee
@@ -30,7 +30,7 @@
 
 plugin = (robot) ->
   apiKey = process.env.HUBOT_NEWRELIC_API_KEY
-  apiHost = process.env.HUBOT_NEWRELIC_API_HOST
+  apiHost = process.env.HUBOT_NEWRELIC_API_HOST or 'api.newrelic.com'
   apiBaseUrl = "https://#{apiHost}/v2/"
   config = {}
 


### PR DESCRIPTION
Avoids needing to set `HUBOT_NEWRELIC_API_HOST` if you do not have an alternative API hostname you wish to use.