### PR TITLE
Add proper error handling if API key is not set. Improves #13

### DIFF
--- a/src/newrelic.coffee
+++ b/src/newrelic.coffee
@@ -72,10 +72,14 @@ plugin = (robot) ->
   _request = (path, cb) ->
     robot.http(apiBaseUrl + path)
       .header('X-Api-Key', apiKey)
-      .header("Content-Type","application/x-www-form-urlencoded")
+      .header('Content-Type','application/x-www-form-urlencoded')
 
-  get = (path, cb) -> _request(path).get() _parse_response(cb)
-  post = (path, data, cb) -> _request(path).post(data) _parse_response(cb)
+  get = (path, cb) ->
+    return cb({message:'HUBOT_NEWRELIC_API_KEY is not set'}) if !apiKey
+    _request(path).get() _parse_response(cb)
+  post = (path, data, cb) ->
+    return cb({message:'HUBOT_NEWRELIC_API_KEY is not set'}) if !apiKey
+    _request(path).post(data) _parse_response(cb)
 
   robot.respond /(newrelic|nr) help$/i, (msg) ->
     msg.send "


### PR DESCRIPTION
Shows a proper error message to the user if the API key is not set. 

This improves upon the behavior described in #13, whereby an unset API key leads to a suppressed error and thus a misleading exception being thrown from within scoped-http-client